### PR TITLE
Bugs/1.12/source jar generates with nonexpanded values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,13 @@ jar {
     }
 }
 
+task sourceJar(type: Jar, overwrite: true) {
+    dependsOn processResources
+    from "$buildDir/generated/main/java"
+    from processResources.outputs
+    archiveName = "$archivesBaseName-$version-sources.jar"
+}
+
 task saveConfig {
     doLast {
         def configFile = new File("${projectDir.getAbsolutePath()}/config.json")

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "version": {
         "major": 4,
         "minor": 4,
-        "patch": 3
+        "patch": 4
     },
     "minecraft": {
         "version": "1.12.2"


### PR DESCRIPTION
fixes #9 